### PR TITLE
minor spacing typo in metaprogramming.md

### DIFF
--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -407,10 +407,10 @@ julia> eval(ex)
 The value of `a` is used to construct the expression `ex` which applies the `+` function to the
 value 1 and the variable `b`. Note the important distinction between the way `a` and `b` are used:
 
-  * The value of the *variable*`a` at expression construction time is used as an immediate value in
+  * The value of the *variable* `a` at expression construction time is used as an immediate value in
     the expression. Thus, the value of `a` when the expression is evaluated no longer matters: the
     value in the expression is already `1`, independent of whatever the value of `a` might be.
-  * On the other hand, the *symbol*`:b` is used in the expression construction, so the value of the
+  * On the other hand, the *symbol* `:b` is used in the expression construction, so the value of the
     variable `b` at that time is irrelevant -- `:b` is just a symbol and the variable `b` need not
     even be defined. At expression evaluation time, however, the value of the symbol `:b` is resolved
     by looking up the value of the variable `b`.


### PR DESCRIPTION
I noticed a trivial spacing issue while reading Metaprogramming.